### PR TITLE
Add MOREFLAGS variable to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,15 @@ libzstd.a: $(LIBZSTD_NAME)
 
 $(LIBZSTD_NAME):
 ifeq ($(GOOS_GOARCH),$(GOOS_GOARCH_NATIVE))
-	cd zstd/lib && ZSTD_LEGACY_SUPPORT=0 $(MAKE) clean libzstd.a
+	cd zstd/lib && ZSTD_LEGACY_SUPPORT=0 MOREFLAGS=$(MOREFLAGS) $(MAKE) clean libzstd.a
 	mv zstd/lib/libzstd.a $(LIBZSTD_NAME)
 else
 ifeq ($(GOOS_GOARCH),linux_arm)
-	cd zstd/lib && CC=arm-linux-gnueabi-gcc ZSTD_LEGACY_SUPPORT=0 $(MAKE) clean libzstd.a
+	cd zstd/lib && CC=arm-linux-gnueabi-gcc ZSTD_LEGACY_SUPPORT=0 MOREFLAGS=$(MOREFLAGS) $(MAKE) clean libzstd.a
 	mv zstd/lib/libzstd.a libzstd_linux_arm.a
 endif
 ifeq ($(GOOS_GOARCH),linux_arm64)
-	cd zstd/lib && CC=aarch64-linux-gnu-gcc ZSTD_LEGACY_SUPPORT=0 $(MAKE) clean libzstd.a
+	cd zstd/lib && CC=aarch64-linux-gnu-gcc ZSTD_LEGACY_SUPPORT=0 MOREFLAGS=$(MOREFLAGS) $(MAKE) clean libzstd.a
 	mv zstd/lib/libzstd.a libzstd_linux_arm64.a
 endif
 endif

--- a/README.md
+++ b/README.md
@@ -73,5 +73,8 @@ and [Reader](https://godoc.org/github.com/valyala/gozstd#Reader) for stream deco
   * Q: _I don't trust `libzstd*.a` binary files from the repo or these files dont't work on my OS/ARCH. How to rebuild them?_
     A: Just run `make clean libzstd.a` if your OS/ARCH is supported.
     
+  * Q: _How do I specify custom build flags when recompiling `libzstd*.a`?_
+    A: You can specify MOREFLAGS=... variable when running `make` like this: `MOREFLAGS=-fPIC make clean libzstd.a`.
+
   * Q: _Why the repo contains `libzstd*.a` binary files?_  
     A: This simplifies package installation to usual `go get` without additional steps for building the `libzstd*.a`


### PR DESCRIPTION
The Makefile in zstd project allows specifying `MOREFLAGS` for some
additional flags that might be required during compilation. One such
flag is `-fPIC`.

Example:

    $ MOREFLAGS=-fPIC make clean libzstd.a