### PR TITLE
Allow specifying zstd version when updating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ GOARCH ?= $(shell go env GOARCH)
 GOOS_GOARCH := $(GOOS)_$(GOARCH)
 GOOS_GOARCH_NATIVE := $(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)
 LIBZSTD_NAME := libzstd_$(GOOS_GOARCH).a
+ZSTD_VERSION ?= master
 
 .PHONY: libzstd.a
 
@@ -29,7 +30,7 @@ clean:
 
 update-zstd:
 	rm -rf zstd-tmp
-	git clone --branch master --depth 1 https://github.com/Facebook/zstd zstd-tmp
+	git clone --branch $(ZSTD_VERSION) --depth 1 https://github.com/Facebook/zstd zstd-tmp
 	rm -rf zstd-tmp/.git
 	rm -rf zstd
 	mv zstd-tmp zstd


### PR DESCRIPTION
This commit adds the ability to specify zstd version instead of
`master`.
Example:

    ZSTD_VERSION=v1.4.2 make update-zstd