### PR TITLE
Fixed problem with Writer.ReadFrom()

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -164,14 +164,18 @@ func (zw *Writer) ReadFrom(r io.Reader) (int64, error) {
 		// Fill the inBuf.
 		for zw.inBuf.size < cstreamInBufSize {
 			n, err := r.Read(zw.inBufGo[zw.inBuf.size:cstreamInBufSize])
+
+			// Sometimes n > 0 even when Read() returns an error.
+			// This is true especially if the error is io.EOF.
+			zw.inBuf.size += C.size_t(n)
+			nn += int64(n)
+
 			if err != nil {
 				if err == io.EOF {
 					return nn, nil
 				}
 				return nn, err
 			}
-			zw.inBuf.size += C.size_t(n)
-			nn += int64(n)
 		}
 
 		// Flush the inBuf.


### PR DESCRIPTION
Previously, Writer.ReadFrom() discarded the bytes that were read when the
Read() function of the underlying Reader returned an error. This commit
makes sure those bytes are still accounted for.