### PR TITLE
Support setting a custom window size in Writer

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -90,8 +90,8 @@ const (
 // A WriterParams allows users to specify compression parameters by calling
 // NewWriterParams.
 //
-// Calling NewWriterParams with a zero-value WriterParams is equivalent to
-// calling NewWriter.
+// Calling NewWriterParams with a zero-value or nil WriterParams is equivalent
+// to calling NewWriter.
 type WriterParams struct {
 	// Compression level. Special value 0 means default.
 	CompressionLevel int
@@ -104,7 +104,7 @@ type WriterParams struct {
 	// decompressor requires special treatment.
 	WindowLog int
 
-	// Dict is the dictionnary used for compression. May be nil.
+	// Dict is optional dictionary used for compression.
 	Dict *CDict
 }
 
@@ -115,8 +115,8 @@ type WriterParams struct {
 // to finalize the compressed stream.
 //
 // Call Release when the Writer is no longer needed.
-func NewWriterParams(w io.Writer, params WriterParams) *Writer {
-	return newWriterParams(w, &params)
+func NewWriterParams(w io.Writer, params *WriterParams) *Writer {
+	return newWriterParams(w, params)
 }
 
 func newWriterParams(w io.Writer, params *WriterParams) *Writer {

--- a/writer.go
+++ b/writer.go
@@ -58,7 +58,6 @@ func NewWriterLevel(w io.Writer, compressionLevel int) *Writer {
 	params := &WriterParams{
 		CompressionLevel: compressionLevel,
 	}
-
 	return newWriterParams(w, params)
 }
 
@@ -73,7 +72,6 @@ func NewWriterDict(w io.Writer, cd *CDict) *Writer {
 	params := &WriterParams{
 		Dict: cd,
 	}
-
 	return newWriterParams(w, params)
 }
 

--- a/writer.go
+++ b/writer.go
@@ -151,7 +151,8 @@ func newWriterParams(w io.Writer, params *WriterParams) *Writer {
 }
 
 // Reset resets zw to write to w using the given dictionary cd and the given
-// compressionLevel. Other parameters set via WriterParams remain unchanged.
+// compressionLevel. Use ResetWriterParams if you wish to change other
+// parameters that were set via WriterParams.
 func (zw *Writer) Reset(w io.Writer, cd *CDict, compressionLevel int) {
 	zw.inBuf.size = 0
 	zw.inBuf.pos = 0
@@ -164,6 +165,19 @@ func (zw *Writer) Reset(w io.Writer, cd *CDict, compressionLevel int) {
 		Dict:             cd,
 		WindowLog:        zw.wlog,
 	}
+	initCStream(zw.cs, params)
+
+	zw.w = w
+}
+
+// ResetWriterParams resets zw to write to w using the given set of parameters.
+func (zw *Writer) ResetWriterParams(w io.Writer, params *WriterParams) {
+	zw.inBuf.size = 0
+	zw.inBuf.pos = 0
+	zw.outBuf.size = cstreamOutBufSize
+	zw.outBuf.pos = 0
+
+	zw.cd = params.Dict
 	initCStream(zw.cs, params)
 
 	zw.w = w

--- a/writer.go
+++ b/writer.go
@@ -100,6 +100,10 @@ type WriterParams struct {
 
 	// WindowLog. Must be clamped between WindowLogMin and WindowLogMin32/64.
 	// Special value 0 means 'use default windowLog'.
+	//
+	// Note: enabling log distance matching increases memory usage for both
+	// compressor and decompressor. When set to a value greater than 27, the
+	// decompressor requires special treatment.
 	WindowLog int
 
 	// Dict is the dictionnary used for compression. May be nil.

--- a/writer.go
+++ b/writer.go
@@ -44,7 +44,7 @@ type Writer struct {
 //
 // Call Release when the Writer is no longer needed.
 func NewWriter(w io.Writer) *Writer {
-	return newWriterParams(w, &WriterParams{})
+	return newWriterParams(w, nil)
 }
 
 // NewWriterLevel returns new zstd writer writing compressed data to w
@@ -120,6 +120,10 @@ func NewWriterParams(w io.Writer, params *WriterParams) *Writer {
 }
 
 func newWriterParams(w io.Writer, params *WriterParams) *Writer {
+	if params == nil {
+		params = &WriterParams{}
+	}
+
 	cs := C.ZSTD_createCStream()
 	initCStream(cs, params)
 

--- a/writer.go
+++ b/writer.go
@@ -121,7 +121,7 @@ func NewWriterParams(w io.Writer, params *WriterParams) *Writer {
 	}
 
 	cs := C.ZSTD_createCStream()
-	initCStream(cs, params)
+	initCStream(cs, *params)
 
 	inBuf := (*C.ZSTD_inBuffer)(C.malloc(C.sizeof_ZSTD_inBuffer))
 	inBuf.src = C.malloc(cstreamInBufSize)
@@ -160,7 +160,7 @@ func (zw *Writer) Reset(w io.Writer, cd *CDict, compressionLevel int) {
 	zw.outBuf.pos = 0
 
 	zw.cd = cd
-	params := &WriterParams{
+	params := WriterParams{
 		CompressionLevel: compressionLevel,
 		Dict:             cd,
 		WindowLog:        zw.wlog,
@@ -178,12 +178,12 @@ func (zw *Writer) ResetWriterParams(w io.Writer, params *WriterParams) {
 	zw.outBuf.pos = 0
 
 	zw.cd = params.Dict
-	initCStream(zw.cs, params)
+	initCStream(zw.cs, *params)
 
 	zw.w = w
 }
 
-func initCStream(cs *C.ZSTD_CStream, params *WriterParams) {
+func initCStream(cs *C.ZSTD_CStream, params WriterParams) {
 	if params.Dict != nil {
 		result := C.ZSTD_initCStream_usingCDict(cs, params.Dict.p)
 		ensureNoError("ZSTD_initCStream_usingCDict", result)

--- a/writer.go
+++ b/writer.go
@@ -69,6 +69,34 @@ func NewWriterDict(w io.Writer, cd *CDict) *Writer {
 }
 
 func newWriterDictLevel(w io.Writer, cd *CDict, compressionLevel int) *Writer {
+const (
+	// WindowLogMin is the minimum value of the windowLog parameter.
+	WindowLogMin = 10 // from zstd.h
+	// WindowLogMax32 is the maximum value of the windowLog parameter on 32-bit architectures.
+	WindowLogMax32 = 30 // from zstd.h
+	// WindowLogMax64 is the maximum value of the windowLog parameter on 64-bit architectures.
+	WindowLogMax64 = 31 // from zstd.h
+
+	// DefaultWindowLog is the default value of the windowLog parameter.
+	DefaultWindowLog = 0
+)
+
+// A WriterParams allows users to specify compression parameters by calling
+// NewWriterParams.
+//
+// Calling NewWriterParams with a zero-value WriterParams is equivalent to
+// calling NewWriter.
+type WriterParams struct {
+	// Compression level. Special value 0 means default.
+	CompressionLevel int
+
+	// WindowLog. Must be clamped between WindowLogMin and WindowLogMin32/64.
+	// Special value 0 means 'use default windowLog'.
+	WindowLog int
+
+	// Dict is the dictionnary used for compression. May be nil.
+	Dict *CDict
+}
 	cs := C.ZSTD_createCStream()
 	initCStream(cs, cd, compressionLevel)
 

--- a/writer.go
+++ b/writer.go
@@ -90,10 +90,10 @@ const (
 // A WriterParams allows users to specify compression parameters by calling
 // NewWriterParams.
 //
-// Calling NewWriterParams with a zero-value or nil WriterParams is equivalent
-// to calling NewWriter.
+// Calling NewWriterParams with a nil WriterParams is equivalent to calling
+// NewWriter.
 type WriterParams struct {
-	// Compression level. Special value 0 means default.
+	// Compression level. Special value 0 means 'default compression level'.
 	CompressionLevel int
 
 	// WindowLog. Must be clamped between WindowLogMin and WindowLogMin32/64.

--- a/writer.go
+++ b/writer.go
@@ -44,7 +44,7 @@ type Writer struct {
 //
 // Call Release when the Writer is no longer needed.
 func NewWriter(w io.Writer) *Writer {
-	return newWriterParams(w, nil)
+	return NewWriterParams(w, nil)
 }
 
 // NewWriterLevel returns new zstd writer writing compressed data to w
@@ -58,7 +58,7 @@ func NewWriterLevel(w io.Writer, compressionLevel int) *Writer {
 	params := &WriterParams{
 		CompressionLevel: compressionLevel,
 	}
-	return newWriterParams(w, params)
+	return NewWriterParams(w, params)
 }
 
 // NewWriterDict returns new zstd writer writing compressed data to w
@@ -72,7 +72,7 @@ func NewWriterDict(w io.Writer, cd *CDict) *Writer {
 	params := &WriterParams{
 		Dict: cd,
 	}
-	return newWriterParams(w, params)
+	return NewWriterParams(w, params)
 }
 
 const (
@@ -116,10 +116,6 @@ type WriterParams struct {
 //
 // Call Release when the Writer is no longer needed.
 func NewWriterParams(w io.Writer, params *WriterParams) *Writer {
-	return newWriterParams(w, params)
-}
-
-func newWriterParams(w io.Writer, params *WriterParams) *Writer {
 	if params == nil {
 		params = &WriterParams{}
 	}

--- a/writer.go
+++ b/writer.go
@@ -154,20 +154,12 @@ func NewWriterParams(w io.Writer, params *WriterParams) *Writer {
 // compressionLevel. Use ResetWriterParams if you wish to change other
 // parameters that were set via WriterParams.
 func (zw *Writer) Reset(w io.Writer, cd *CDict, compressionLevel int) {
-	zw.inBuf.size = 0
-	zw.inBuf.pos = 0
-	zw.outBuf.size = cstreamOutBufSize
-	zw.outBuf.pos = 0
-
-	zw.cd = cd
 	params := WriterParams{
 		CompressionLevel: compressionLevel,
-		Dict:             cd,
 		WindowLog:        zw.wlog,
+		Dict:             cd,
 	}
-	initCStream(zw.cs, params)
-
-	zw.w = w
+	zw.ResetWriterParams(w, &params)
 }
 
 // ResetWriterParams resets zw to write to w using the given set of parameters.

--- a/writer_example_test.go
+++ b/writer_example_test.go
@@ -101,3 +101,31 @@ func ExampleWriter_Reset() {
 	// line 1
 	// line 2
 }
+
+func ExampleWriterParams() {
+
+	// Compress data to bb.
+	var bb bytes.Buffer
+	zw := NewWriterParams(&bb, WriterParams{
+		CompressionLevel: 10,
+		WindowLog:        14,
+	})
+	defer zw.Release()
+
+	for i := 0; i < 3; i++ {
+		fmt.Fprintf(zw, "line %d\n", i)
+	}
+	if err := zw.Close(); err != nil {
+		log.Fatalf("cannot close writer: %s", err)
+	}
+
+	// Decompress the data and verify it is valid.
+	plainData, err := Decompress(nil, bb.Bytes())
+	fmt.Printf("err: %v\n%s", err, plainData)
+
+	// Output:
+	// err: <nil>
+	// line 0
+	// line 1
+	// line 2
+}

--- a/writer_example_test.go
+++ b/writer_example_test.go
@@ -106,7 +106,7 @@ func ExampleWriterParams() {
 
 	// Compress data to bb.
 	var bb bytes.Buffer
-	zw := NewWriterParams(&bb, WriterParams{
+	zw := NewWriterParams(&bb, &WriterParams{
 		CompressionLevel: 10,
 		WindowLog:        14,
 	})

--- a/writer_test.go
+++ b/writer_test.go
@@ -202,7 +202,7 @@ func TestWriterWindowLog(t *testing.T) {
 	src := []byte(newTestString(512, 3))
 	for level := 0; level < 23; level++ {
 		for wlog := WindowLogMin; wlog <= wlogMax; wlog++ {
-			params := WriterParams{
+			params := &WriterParams{
 				CompressionLevel: level,
 				WindowLog:        wlog,
 			}

--- a/writer_timing_test.go
+++ b/writer_timing_test.go
@@ -76,3 +76,17 @@ func benchmarkWriter(b *testing.B, blockSize, level int) {
 		}
 	})
 }
+
+func BenchmarkWriterResetAlloc(b *testing.B) {
+	b.ReportAllocs()
+
+	params := &WriterParams{}
+
+	zw := NewWriter(ioutil.Discard)
+	defer zw.Release()
+
+	for n := 0; n < b.N; n++ {
+		zw.Reset(ioutil.Discard, nil, 0)
+		zw.ResetWriterParams(ioutil.Discard, params)
+	}
+}


### PR DESCRIPTION
In #7 this adds support to custom window size (called WindowLog in the code, as in libzstd).

As discussed, setting this parameter is performed via a `WriterParams` structure in which letting all values to their default is equivalent to calling `NewWriter`.

I took the liberty to modify `newWriterParams` the non-public Writer constructor so that it now takes a `WriterParam` instead of having to add a new parameter to it.
One example and 1 test have been added.

Fixes #7 