### PR TITLE
Fix memory leaks in writer test case

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -227,6 +227,7 @@ func TestWriterWindowLog(t *testing.T) {
 			if !bytes.Equal(plainData, src) {
 				t.Fatalf("unexpected data obtained after decompression on level %d wlog %d; got\n%X; want\n%X", level, wlog, plainData, src)
 			}
+			zr.Release()
 		}
 	}
 }
@@ -432,7 +433,9 @@ func testWriterExt(zw *Writer, s string) error {
 func TestWriterBig(t *testing.T) {
 	pr, pw := io.Pipe()
 	zw := NewWriter(pw)
+	defer zw.Release()
 	zr := NewReader(pr)
+	defer zr.Release()
 
 	doneCh := make(chan error)
 	var writtenBB bytes.Buffer


### PR DESCRIPTION
This causes the test to fail on 32-bit systems, as the system exhausts its available address space due to the leaks.

An example failure https://ci.debian.net/data/autopkgtest/testing/i386/g/golang-github-valyala-gozstd/9646307/log.gz.