### PR TITLE
build: enable build without cgo

### DIFF
--- a/dict_nocgo.go
+++ b/dict_nocgo.go
@@ -1,0 +1,7 @@
+package gozstd
+
+type CDict struct {
+}
+
+type DDict struct {
+}

--- a/gozstd_nocgo.go
+++ b/gozstd_nocgo.go
@@ -1,0 +1,41 @@
+// +build !cgo
+
+package gozstd
+
+import (
+	"fmt"
+)
+
+// DefaultCompressionLevel is the default compression level.
+const DefaultCompressionLevel = 3 // Obtained from ZSTD_CLEVEL_DEFAULT.
+
+// Compress appends compressed src to dst and returns the result.
+func Compress(dst, src []byte) []byte {
+	return nil
+}
+
+// CompressLevel appends compressed src to dst and returns the result.
+//
+// The given compressionLevel is used for the compression.
+func CompressLevel(dst, src []byte, compressionLevel int) []byte {
+	return nil
+}
+
+// CompressDict appends compressed src to dst and returns the result.
+//
+// The given dictionary is used for the compression.
+func CompressDict(dst, src []byte, cd *CDict) []byte {
+	return nil
+}
+
+// Decompress appends decompressed src to dst and returns the result.
+func Decompress(dst, src []byte) ([]byte, error) {
+	return nil, fmt.Errorf("zstd not supported without cgo")
+}
+
+// DecompressDict appends decompressed src to dst and returns the result.
+//
+// The given dictionary dd is used for the decompression.
+func DecompressDict(dst, src []byte, dd *DDict) ([]byte, error) {
+	return nil, fmt.Errorf("zstd not supported without cgo")
+}

--- a/reader_nocgo.go
+++ b/reader_nocgo.go
@@ -1,0 +1,47 @@
+package gozstd
+
+import (
+	"fmt"
+	"io"
+)
+
+// Reader implements zstd reader.
+type Reader struct {
+}
+
+// NewReader returns new zstd reader reading compressed data from r.
+//
+// Call Release when the Reader is no longer needed.
+func NewReader(r io.Reader) *Reader {
+	return &Reader{}
+}
+
+// NewReaderDict returns new zstd reader reading compressed data from r
+// using the given DDict.
+//
+// Call Release when the Reader is no longer needed.
+func NewReaderDict(r io.Reader, dd *DDict) *Reader {
+	return &Reader{}
+}
+
+// Reset resets zr to read from r using the given dictionary dd.
+func (zr *Reader) Reset(r io.Reader, dd *DDict) {
+}
+
+// Release releases all the resources occupied by zr.
+//
+// zr cannot be used after the release.
+func (zr *Reader) Release() {
+}
+
+// WriteTo writes all the data from zr to w.
+//
+// It returns the number of bytes written to w.
+func (zr *Reader) WriteTo(w io.Writer) (int64, error) {
+	return -1, fmt.Errorf("zstd not supported without cgo")
+}
+
+// Read reads up to len(p) bytes from zr to p.
+func (zr *Reader) Read(p []byte) (int, error) {
+	return -1, fmt.Errorf("zstd not supported without cgo")
+}

--- a/writer_nocgo.go
+++ b/writer_nocgo.go
@@ -1,0 +1,121 @@
+package gozstd
+
+import (
+	"fmt"
+	"io"
+)
+
+type Writer struct {
+}
+
+// NewWriter returns new zstd writer writing compressed data to w.
+//
+// The returned writer must be closed with Close call in order
+// to finalize the compressed stream.
+//
+// Call Release when the Writer is no longer needed.
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{}
+}
+
+// NewWriterLevel returns new zstd writer writing compressed data to w
+// at the given compression level.
+//
+// The returned writer must be closed with Close call in order
+// to finalize the compressed stream.
+//
+// Call Release when the Writer is no longer needed.
+func NewWriterLevel(w io.Writer, compressionLevel int) *Writer {
+	return &Writer{}
+}
+
+// NewWriterDict returns new zstd writer writing compressed data to w
+// using the given cd.
+//
+// The returned writer must be closed with Close call in order
+// to finalize the compressed stream.
+//
+// Call Release when the Writer is no longer needed.
+func NewWriterDict(w io.Writer, cd *CDict) *Writer {
+	return &Writer{}
+}
+
+// A WriterParams allows users to specify compression parameters by calling
+// NewWriterParams.
+//
+// Calling NewWriterParams with a nil WriterParams is equivalent to calling
+// NewWriter.
+type WriterParams struct {
+	// Compression level. Special value 0 means 'default compression level'.
+	CompressionLevel int
+
+	// WindowLog. Must be clamped between WindowLogMin and WindowLogMin32/64.
+	// Special value 0 means 'use default windowLog'.
+	//
+	// Note: enabling log distance matching increases memory usage for both
+	// compressor and decompressor. When set to a value greater than 27, the
+	// decompressor requires special treatment.
+	WindowLog int
+
+	// Dict is optional dictionary used for compression.
+	Dict *CDict
+}
+
+// NewWriterParams returns new zstd writer writing compressed data to w
+// using the given set of parameters.
+//
+// The returned writer must be closed with Close call in order
+// to finalize the compressed stream.
+//
+// Call Release when the Writer is no longer needed.
+func NewWriterParams(w io.Writer, params *WriterParams) *Writer {
+	return &Writer{}
+}
+
+// Reset resets zw to write to w using the given dictionary cd and the given
+// compressionLevel. Use ResetWriterParams if you wish to change other
+// parameters that were set via WriterParams.
+func (zw *Writer) Reset(w io.Writer, cd *CDict, compressionLevel int) {
+}
+
+// ResetWriterParams resets zw to write to w using the given set of parameters.
+func (zw *Writer) ResetWriterParams(w io.Writer, params *WriterParams) {
+}
+
+func (zw *Writer) Release() {
+}
+
+// ReadFrom reads all the data from r and writes it to zw.
+//
+// Returns the number of bytes read from r.
+//
+// ReadFrom may not flush the compressed data to the underlying writer
+// due to performance reasons.
+// Call Flush or Close when the compressed data must propagate
+// to the underlying writer.
+func (zw *Writer) ReadFrom(r io.Reader) (int64, error) {
+	return -1, fmt.Errorf("zstd not supported without cgo")
+}
+
+// Write writes p to zw.
+//
+// Write doesn't flush the compressed data to the underlying writer
+// due to performance reasons.
+// Call Flush or Close when the compressed data must propagate
+// to the underlying writer.
+func (zw *Writer) Write(p []byte) (int, error) {
+	return -1, fmt.Errorf("zstd not supported without cgo")
+}
+
+// Flush flushes the remaining data from zw to the underlying writer.
+func (zw *Writer) Flush() error {
+	return fmt.Errorf("zstd not supported without cgo")
+}
+
+// Close finalizes the compressed stream and flushes all the compressed data
+// to the underlying writer.
+//
+// It doesn't close the underlying writer passed to New* functions.
+func (zw *Writer) Close() error {
+	return fmt.Errorf("zstd not supported without cgo")
+}


### PR DESCRIPTION
we have moved from github.com/klauspost/compress to github.com/valyala/gozstd in github.com/containers/storage for performance reasons when pulling container images, but unfortunately we need to support build also on targets where cgo is missing: https://github.com/containers/podman/pull/12794

Without this PR, I get:

```
$ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
# github.com/valyala/gozstd
./stream.go:14:48: undefined: DefaultCompressionLevel
./stream.go:31:59: undefined: CDict
./stream.go:35:64: undefined: CDict
./stream.go:47:20: undefined: Writer
./stream.go:56:22: undefined: NewWriterLevel
./stream.go:101:61: undefined: DDict
./stream.go:110:6: undefined: Reader
./stream.go:117:8: undefined: NewReader
```

now the build works fine

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
