### PR TITLE
dicts: Add option to use the *_byReference variants at creation time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ update-zstd:
 	cp zstd/lib/zstd_errors.h .
 
 test:
-	CGO_ENABLED=1 GODEBUG=cgocheck=2 go test -v
+	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 go test -v
 
 bench:
 	CGO_ENABLED=1 go test -bench=.

--- a/dict.go
+++ b/dict.go
@@ -23,6 +23,14 @@ static ZSTD_DDict* ZSTD_createDDict_wrapper(uintptr_t dictBuffer, size_t dictSiz
 	return ZSTD_createDDict((const void *)dictBuffer, dictSize);
 }
 
+static ZSTD_CDict* ZSTD_createCDict_byReference_wrapper(uintptr_t dictBuffer, size_t dictSize, int compressionLevel) {
+	return ZSTD_createCDict_byReference((const void *)dictBuffer, dictSize, compressionLevel);
+}
+
+static ZSTD_DDict* ZSTD_createDDict_byReference_wrapper(uintptr_t dictBuffer, size_t dictSize) {
+	return ZSTD_createDDict_byReference((const void *)dictBuffer, dictSize);
+}
+
 */
 import "C"
 
@@ -103,7 +111,9 @@ var buildDictLock sync.Mutex
 //
 // A single CDict may be re-used in concurrently running goroutines.
 type CDict struct {
-	p                *C.ZSTD_CDict
+	p *C.ZSTD_CDict
+	// Keep the underlying bytes alive from the GC's point of view (if passing by ref)
+	input            []byte
 	compressionLevel int
 }
 
@@ -112,6 +122,16 @@ type CDict struct {
 // Call Release when the returned dict is no longer used.
 func NewCDict(dict []byte) (*CDict, error) {
 	return NewCDictLevel(dict, DefaultCompressionLevel)
+}
+
+// NewCDictByRef creates a new CDict that shares the given dict
+//
+// Callers *must not* mutate the underlying array of 'dict'. Doing so will lead
+// to undefined and undesirable behavior.
+//
+// Call Release when the returned dict is no longer used.
+func NewCDictByRef(dict []byte) (*CDict, error) {
+	return NewCDictLevelByRef(dict, DefaultCompressionLevel)
 }
 
 // NewCDictLevel creates new CDict from the given dict
@@ -136,6 +156,32 @@ func NewCDictLevel(dict []byte, compressionLevel int) (*CDict, error) {
 	return cd, nil
 }
 
+// NewCDictLevelByRef creates a new CDict that shares the given dict using
+// the given compressionLevel.
+//
+// Callers *must not* mutate the underlying array of 'dict'. Doing so will lead
+// to undefined and undesirable behavior.
+//
+// Call Release when the returned dict is no longer used.
+func NewCDictLevelByRef(dict []byte, compressionLevel int) (*CDict, error) {
+	if len(dict) == 0 {
+		return nil, fmt.Errorf("dict cannot be empty")
+	}
+
+	cd := &CDict{
+		p: C.ZSTD_createCDict_byReference_wrapper(
+			C.uintptr_t(uintptr(unsafe.Pointer(&dict[0]))),
+			C.size_t(len(dict)),
+			C.int(compressionLevel)),
+		input:            dict,
+		compressionLevel: compressionLevel,
+	}
+	// Prevent from GC'ing of dict during CGO call above.
+	runtime.KeepAlive(dict)
+	runtime.SetFinalizer(cd, freeCDict)
+	return cd, nil
+}
+
 // Release releases resources occupied by cd.
 //
 // cd cannot be used after the release.
@@ -146,6 +192,7 @@ func (cd *CDict) Release() {
 	result := C.ZSTD_freeCDict(cd.p)
 	ensureNoError("ZSTD_freeCDict", result)
 	cd.p = nil
+	cd.input = nil
 }
 
 func freeCDict(v interface{}) {
@@ -157,6 +204,8 @@ func freeCDict(v interface{}) {
 // A single DDict may be re-used in concurrently running goroutines.
 type DDict struct {
 	p *C.ZSTD_DDict
+	// Keep the underlying bytes alive from the GC's point of view (if passing by ref)
+	input []byte
 }
 
 // NewDDict creates new DDict from the given dict.
@@ -178,6 +227,29 @@ func NewDDict(dict []byte) (*DDict, error) {
 	return dd, nil
 }
 
+// NewDDictByRef creates a new DDict that shares the given dict
+//
+// Callers *must not* mutate the underlying array of 'dict'. Doing so will lead
+// to undefined and undesirable behavior.
+//
+// Call Release when the returned dict is no longer needed.
+func NewDDictByRef(dict []byte) (*DDict, error) {
+	if len(dict) == 0 {
+		return nil, fmt.Errorf("dict cannot be empty")
+	}
+
+	dd := &DDict{
+		p: C.ZSTD_createDDict_byReference_wrapper(
+			C.uintptr_t(uintptr(unsafe.Pointer(&dict[0]))),
+			C.size_t(len(dict))),
+		input: dict,
+	}
+	// Prevent from GC'ing of dict during CGO call above.
+	runtime.KeepAlive(dict)
+	runtime.SetFinalizer(dd, freeDDict)
+	return dd, nil
+}
+
 // Release releases resources occupied by dd.
 //
 // dd cannot be used after the release.
@@ -189,6 +261,7 @@ func (dd *DDict) Release() {
 	result := C.ZSTD_freeDDict(dd.p)
 	ensureNoError("ZSTD_freeDDict", result)
 	dd.p = nil
+	dd.input = nil
 }
 
 func freeDDict(v interface{}) {

--- a/dict_test.go
+++ b/dict_test.go
@@ -43,6 +43,22 @@ func TestCDictCreateRelease(t *testing.T) {
 	}
 }
 
+func TestCDictByRefCreateRelease(t *testing.T) {
+	var samples [][]byte
+	for i := 0; i < 1000; i++ {
+		samples = append(samples, []byte(fmt.Sprintf("sample %d", i)))
+	}
+	dict := BuildDict(samples, 64*1024)
+
+	for i := 0; i < 10; i++ {
+		cd, err := NewCDictByRef(dict)
+		if err != nil {
+			t.Fatalf("cannot create dict: %s", err)
+		}
+		cd.Release()
+	}
+}
+
 func TestDDictCreateRelease(t *testing.T) {
 	var samples [][]byte
 	for i := 0; i < 1000; i++ {
@@ -52,6 +68,22 @@ func TestDDictCreateRelease(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		dd, err := NewDDict(dict)
+		if err != nil {
+			t.Fatalf("cannot create dict: %s", err)
+		}
+		dd.Release()
+	}
+}
+
+func TestDDictByRefCreateRelease(t *testing.T) {
+	var samples [][]byte
+	for i := 0; i < 1000; i++ {
+		samples = append(samples, []byte(fmt.Sprintf("sample %d", i)))
+	}
+	dict := BuildDict(samples, 64*1024)
+
+	for i := 0; i < 10; i++ {
+		dd, err := NewDDictByRef(dict)
 		if err != nil {
 			t.Fatalf("cannot create dict: %s", err)
 		}


### PR DESCRIPTION
# Summary

Related issue:  #59

This adds two additional functions to create a `CDict` or `DDict`:

- `NewCDictByRef(dict []byte) (*CDict, error)`
    - (OK, technically three with the corresponding `NewCDictLevelByRef`)
- `NewDDictByRef(dict []byte) (*DDict, error)`

My particular use-case is having hundreds (~500-2000) of dictionaries cached locally in-memory, and not wanting to potentially have three copies of each.

- The raw bytes
- The bytes copied and used by the `CDict`
- The bytes copied and used by the `DDict`

To mitigate the risk of the input bytes being garbage collected, they get included as struct members on`gozstd.CDict` and `gozstd.DDict`, and set to `nil` on `Release()`. There's still risk of users mutating the input, but this is advised against in the documentation. Users of this feature implicitly accept the risks of optimization.

# Test Plan

I've added two types of tests:

- The `gozstd_timing_test` benchmarks
- The concurrent compressor / decompressor tests
    - `TestCompressDecompressDistinctConcurrentDictsByRef`

I'm happy to add more if you think it reasonable, but I think this stresses the right things: making sure that the same underlying bytes can be used concurrently with `CDict` and `DDict`.

<details><summary>Command Output</summary>
<p>

```
> make test

CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 go test -v
=== RUN   TestCDictEmpty
--- PASS: TestCDictEmpty (0.00s)
=== RUN   TestDDictEmpty
--- PASS: TestDDictEmpty (0.00s)
=== RUN   TestCDictCreateRelease
--- PASS: TestCDictCreateRelease (0.01s)
=== RUN   TestCDictByRefCreateRelease
--- PASS: TestCDictByRefCreateRelease (0.01s)
=== RUN   TestDDictCreateRelease
--- PASS: TestDDictCreateRelease (0.01s)
=== RUN   TestDDictByRefCreateRelease
--- PASS: TestDDictByRefCreateRelease (0.01s)
=== RUN   TestBuildDict
=== RUN   TestBuildDict/samples_0
=== RUN   TestBuildDict/samples_0/desiredDictLen_20
=== RUN   TestBuildDict/samples_0/desiredDictLen_256
=== RUN   TestBuildDict/samples_0/desiredDictLen_1000
=== RUN   TestBuildDict/samples_0/desiredDictLen_10000
=== RUN   TestBuildDict/samples_1
=== RUN   TestBuildDict/samples_1/desiredDictLen_20
=== RUN   TestBuildDict/samples_1/desiredDictLen_256
=== RUN   TestBuildDict/samples_1/desiredDictLen_1000
=== RUN   TestBuildDict/samples_1/desiredDictLen_10000
=== RUN   TestBuildDict/samples_10
=== RUN   TestBuildDict/samples_10/desiredDictLen_20
=== RUN   TestBuildDict/samples_10/desiredDictLen_256
=== RUN   TestBuildDict/samples_10/desiredDictLen_1000
=== RUN   TestBuildDict/samples_10/desiredDictLen_10000
=== RUN   TestBuildDict/samples_100
=== RUN   TestBuildDict/samples_100/desiredDictLen_20
=== RUN   TestBuildDict/samples_100/desiredDictLen_256
=== RUN   TestBuildDict/samples_100/desiredDictLen_1000
=== RUN   TestBuildDict/samples_100/desiredDictLen_10000
=== RUN   TestBuildDict/samples_1000
=== RUN   TestBuildDict/samples_1000/desiredDictLen_20
=== RUN   TestBuildDict/samples_1000/desiredDictLen_256
=== RUN   TestBuildDict/samples_1000/desiredDictLen_1000
=== RUN   TestBuildDict/samples_1000/desiredDictLen_10000
--- PASS: TestBuildDict (0.16s)
    --- PASS: TestBuildDict/samples_0 (0.02s)
        --- PASS: TestBuildDict/samples_0/desiredDictLen_20 (0.00s)
        --- PASS: TestBuildDict/samples_0/desiredDictLen_256 (0.00s)
        --- PASS: TestBuildDict/samples_0/desiredDictLen_1000 (0.01s)
        --- PASS: TestBuildDict/samples_0/desiredDictLen_10000 (0.01s)
    --- PASS: TestBuildDict/samples_1 (0.02s)
        --- PASS: TestBuildDict/samples_1/desiredDictLen_20 (0.00s)
        --- PASS: TestBuildDict/samples_1/desiredDictLen_256 (0.00s)
        --- PASS: TestBuildDict/samples_1/desiredDictLen_1000 (0.01s)
        --- PASS: TestBuildDict/samples_1/desiredDictLen_10000 (0.01s)
    --- PASS: TestBuildDict/samples_10 (0.02s)
        --- PASS: TestBuildDict/samples_10/desiredDictLen_20 (0.00s)
        --- PASS: TestBuildDict/samples_10/desiredDictLen_256 (0.00s)
        --- PASS: TestBuildDict/samples_10/desiredDictLen_1000 (0.01s)
        --- PASS: TestBuildDict/samples_10/desiredDictLen_10000 (0.01s)
    --- PASS: TestBuildDict/samples_100 (0.03s)
        --- PASS: TestBuildDict/samples_100/desiredDictLen_20 (0.00s)
        --- PASS: TestBuildDict/samples_100/desiredDictLen_256 (0.00s)
        --- PASS: TestBuildDict/samples_100/desiredDictLen_1000 (0.01s)
        --- PASS: TestBuildDict/samples_100/desiredDictLen_10000 (0.01s)
    --- PASS: TestBuildDict/samples_1000 (0.06s)
        --- PASS: TestBuildDict/samples_1000/desiredDictLen_20 (0.01s)
        --- PASS: TestBuildDict/samples_1000/desiredDictLen_256 (0.01s)
        --- PASS: TestBuildDict/samples_1000/desiredDictLen_1000 (0.01s)
        --- PASS: TestBuildDict/samples_1000/desiredDictLen_10000 (0.03s)
=== RUN   TestDecompressSmallBlockWithoutSingleSegmentFlag
=== RUN   TestDecompressSmallBlockWithoutSingleSegmentFlag/empty-dst-buf
=== RUN   TestDecompressSmallBlockWithoutSingleSegmentFlag/small-dst-buf
=== RUN   TestDecompressSmallBlockWithoutSingleSegmentFlag/enough-dst-buf
--- PASS: TestDecompressSmallBlockWithoutSingleSegmentFlag (0.00s)
    --- PASS: TestDecompressSmallBlockWithoutSingleSegmentFlag/empty-dst-buf (0.00s)
    --- PASS: TestDecompressSmallBlockWithoutSingleSegmentFlag/small-dst-buf (0.00s)
    --- PASS: TestDecompressSmallBlockWithoutSingleSegmentFlag/enough-dst-buf (0.00s)
=== RUN   TestCompressDecompressDistinctConcurrentDicts
--- PASS: TestCompressDecompressDistinctConcurrentDicts (0.03s)
=== RUN   TestCompressDecompressDistinctConcurrentDictsByRef
--- PASS: TestCompressDecompressDistinctConcurrentDictsByRef (0.03s)
=== RUN   TestCompressDecompressDict
--- PASS: TestCompressDecompressDict (0.01s)
=== RUN   TestDecompressInvalidData
--- PASS: TestDecompressInvalidData (0.00s)
=== RUN   TestCompressLevel
--- PASS: TestCompressLevel (0.00s)
=== RUN   TestCompressDecompress
--- PASS: TestCompressDecompress (0.05s)
=== RUN   TestCompressDecompressMultiFrames
--- PASS: TestCompressDecompressMultiFrames (0.00s)
=== RUN   TestReaderReadCompressBomb
--- PASS: TestReaderReadCompressBomb (0.00s)
=== RUN   TestReaderWriteTo
--- PASS: TestReaderWriteTo (0.00s)
=== RUN   TestReaderDict
--- PASS: TestReaderDict (0.06s)
=== RUN   TestReaderMultiFrames
--- PASS: TestReaderMultiFrames (0.00s)
=== RUN   TestReaderBadUnderlyingReader
--- PASS: TestReaderBadUnderlyingReader (0.00s)
=== RUN   TestReaderInvalidData
--- PASS: TestReaderInvalidData (0.00s)
=== RUN   TestReader
--- PASS: TestReader (0.03s)
=== RUN   TestStreamCompressDecompress
--- PASS: TestStreamCompressDecompress (0.00s)
=== RUN   TestStreamCompressDecompressLevel
=== RUN   TestStreamCompressDecompressLevel/level_0
=== RUN   TestStreamCompressDecompressLevel/level_1
=== RUN   TestStreamCompressDecompressLevel/level_2
=== RUN   TestStreamCompressDecompressLevel/level_3
=== RUN   TestStreamCompressDecompressLevel/level_4
=== RUN   TestStreamCompressDecompressLevel/level_5
=== RUN   TestStreamCompressDecompressLevel/level_6
=== RUN   TestStreamCompressDecompressLevel/level_7
=== RUN   TestStreamCompressDecompressLevel/level_8
=== RUN   TestStreamCompressDecompressLevel/level_9
=== RUN   TestStreamCompressDecompressLevel/level_10
=== RUN   TestStreamCompressDecompressLevel/level_11
=== RUN   TestStreamCompressDecompressLevel/level_12
=== RUN   TestStreamCompressDecompressLevel/level_13
=== RUN   TestStreamCompressDecompressLevel/level_14
=== RUN   TestStreamCompressDecompressLevel/level_15
=== RUN   TestStreamCompressDecompressLevel/level_16
=== RUN   TestStreamCompressDecompressLevel/level_17
=== RUN   TestStreamCompressDecompressLevel/level_18
=== RUN   TestStreamCompressDecompressLevel/level_19
--- PASS: TestStreamCompressDecompressLevel (0.29s)
    --- PASS: TestStreamCompressDecompressLevel/level_0 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_1 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_2 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_3 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_4 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_5 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_6 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_7 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_8 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_9 (0.00s)
    --- PASS: TestStreamCompressDecompressLevel/level_10 (0.01s)
    --- PASS: TestStreamCompressDecompressLevel/level_11 (0.01s)
    --- PASS: TestStreamCompressDecompressLevel/level_12 (0.01s)
    --- PASS: TestStreamCompressDecompressLevel/level_13 (0.01s)
    --- PASS: TestStreamCompressDecompressLevel/level_14 (0.03s)
    --- PASS: TestStreamCompressDecompressLevel/level_15 (0.06s)
    --- PASS: TestStreamCompressDecompressLevel/level_16 (0.01s)
    --- PASS: TestStreamCompressDecompressLevel/level_17 (0.03s)
    --- PASS: TestStreamCompressDecompressLevel/level_18 (0.01s)
    --- PASS: TestStreamCompressDecompressLevel/level_19 (0.09s)
=== RUN   TestStreamCompressDecompressDict
--- PASS: TestStreamCompressDecompressDict (0.02s)
=== RUN   TestWriterReadFromWithEOF
--- PASS: TestWriterReadFromWithEOF (0.00s)
=== RUN   TestWriterReadFrom
--- PASS: TestWriterReadFrom (0.00s)
=== RUN   TestNewWriterLevel
--- PASS: TestNewWriterLevel (0.23s)
=== RUN   TestWriterDict
--- PASS: TestWriterDict (0.05s)
=== RUN   TestWriterWindowLog
--- PASS: TestWriterWindowLog (2.41s)
=== RUN   TestWriterResetWriterParams
--- PASS: TestWriterResetWriterParams (0.08s)
=== RUN   TestWriterMultiFrames
--- PASS: TestWriterMultiFrames (0.00s)
=== RUN   TestWriterBadUnderlyingWriter
--- PASS: TestWriterBadUnderlyingWriter (0.00s)
=== RUN   TestWriter
--- PASS: TestWriter (0.03s)
=== RUN   TestWriterBig
--- PASS: TestWriterBig (0.05s)
=== RUN   ExampleBuildDict
--- PASS: ExampleBuildDict (0.01s)
=== RUN   ExampleCompress_simple
--- PASS: ExampleCompress_simple (0.00s)
=== RUN   ExampleDecompress_simple
--- PASS: ExampleDecompress_simple (0.00s)
=== RUN   ExampleCompress_noAllocs
--- PASS: ExampleCompress_noAllocs (0.00s)
=== RUN   ExampleDecompress_noAllocs
--- PASS: ExampleDecompress_noAllocs (0.00s)
=== RUN   ExampleReader
--- PASS: ExampleReader (0.00s)
=== RUN   ExampleReader_Reset
--- PASS: ExampleReader_Reset (0.00s)
=== RUN   ExampleWriter
--- PASS: ExampleWriter (0.00s)
=== RUN   ExampleWriter_Flush
--- PASS: ExampleWriter_Flush (0.00s)
=== RUN   ExampleWriter_Reset
--- PASS: ExampleWriter_Reset (0.00s)
=== RUN   ExampleWriterParams
--- PASS: ExampleWriterParams (0.00s)
PASS
ok  	github.com/valyala/gozstd	3.771s

```

</p>
</details> 
