### PR TITLE
Avoid cgo bug by use C.calloc to allocate memory in C instead of C.ma…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ update-zstd:
 	cp zstd/lib/zstd_errors.h .
 
 test:
-	CGO_ENABLED=1 GODEBUG=cgocheck=2 go test -v
+	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 go test -v
 
 bench:
 	CGO_ENABLED=1 go test -bench=.

--- a/reader.go
+++ b/reader.go
@@ -73,13 +73,13 @@ func NewReaderDict(r io.Reader, dd *DDict) *Reader {
 	ds := C.ZSTD_createDStream()
 	initDStream(ds, dd)
 
-	inBuf := (*C.ZSTD_inBuffer)(C.malloc(C.sizeof_ZSTD_inBuffer))
-	inBuf.src = C.malloc(dstreamInBufSize)
+	inBuf := (*C.ZSTD_inBuffer)(C.calloc(1, C.sizeof_ZSTD_inBuffer))
+	inBuf.src = C.calloc(1, dstreamInBufSize)
 	inBuf.size = 0
 	inBuf.pos = 0
 
-	outBuf := (*C.ZSTD_outBuffer)(C.malloc(C.sizeof_ZSTD_outBuffer))
-	outBuf.dst = C.malloc(dstreamOutBufSize)
+	outBuf := (*C.ZSTD_outBuffer)(C.calloc(1, C.sizeof_ZSTD_outBuffer))
+	outBuf.dst = C.calloc(1, dstreamOutBufSize)
 	outBuf.size = 0
 	outBuf.pos = 0
 

--- a/writer.go
+++ b/writer.go
@@ -160,13 +160,13 @@ func NewWriterParams(w io.Writer, params *WriterParams) *Writer {
 	cs := C.ZSTD_createCStream()
 	initCStream(cs, *params)
 
-	inBuf := (*C.ZSTD_inBuffer)(C.malloc(C.sizeof_ZSTD_inBuffer))
-	inBuf.src = C.malloc(cstreamInBufSize)
+	inBuf := (*C.ZSTD_inBuffer)(C.calloc(1, C.sizeof_ZSTD_inBuffer))
+	inBuf.src = C.calloc(1, cstreamInBufSize)
 	inBuf.size = 0
 	inBuf.pos = 0
 
-	outBuf := (*C.ZSTD_outBuffer)(C.malloc(C.sizeof_ZSTD_outBuffer))
-	outBuf.dst = C.malloc(cstreamOutBufSize)
+	outBuf := (*C.ZSTD_outBuffer)(C.calloc(1, C.sizeof_ZSTD_outBuffer))
+	outBuf.dst = C.calloc(1, cstreamOutBufSize)
 	outBuf.size = cstreamOutBufSize
 	outBuf.pos = 0
 


### PR DESCRIPTION
…lloc,

See https://pkg.go.dev/cmd/cgo:

> Note: the current implementation has a bug. While Go code is permitted to write nil or a C pointer (but not a Go pointer) to C memory, the current implementation may sometimes cause a runtime error if the contents of the C memory appear to be a Go pointer. Therefore, avoid passing uninitialized C memory to Go code if the Go code is going to store pointer values in it. Zero out the memory in C before passing it to Go.

I also find similar approach use by Dgraph according to this blog post:
https://dgraph.io/blog/post/manual-memory-management-golang-jemalloc/

> So, instead of using malloc, we use its slightly more expensive sibling, [calloc](https://linux.die.net/man/3/calloc). calloc works the same way as malloc, except it zeroes out the memory before returning it to the caller.