### PR TITLE
prefer malloc when zeroing is not essential

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -74,12 +74,12 @@ func NewReaderDict(r io.Reader, dd *DDict) *Reader {
 	initDStream(ds, dd)
 
 	inBuf := (*C.ZSTD_inBuffer)(C.calloc(1, C.sizeof_ZSTD_inBuffer))
-	inBuf.src = C.calloc(1, dstreamInBufSize)
+	inBuf.src = C.malloc(dstreamInBufSize)
 	inBuf.size = 0
 	inBuf.pos = 0
 
 	outBuf := (*C.ZSTD_outBuffer)(C.calloc(1, C.sizeof_ZSTD_outBuffer))
-	outBuf.dst = C.calloc(1, dstreamOutBufSize)
+	outBuf.dst = C.malloc(dstreamOutBufSize)
 	outBuf.size = 0
 	outBuf.pos = 0
 

--- a/writer.go
+++ b/writer.go
@@ -161,12 +161,12 @@ func NewWriterParams(w io.Writer, params *WriterParams) *Writer {
 	initCStream(cs, *params)
 
 	inBuf := (*C.ZSTD_inBuffer)(C.calloc(1, C.sizeof_ZSTD_inBuffer))
-	inBuf.src = C.calloc(1, cstreamInBufSize)
+	inBuf.src = C.malloc(cstreamInBufSize)
 	inBuf.size = 0
 	inBuf.pos = 0
 
 	outBuf := (*C.ZSTD_outBuffer)(C.calloc(1, C.sizeof_ZSTD_outBuffer))
-	outBuf.dst = C.calloc(1, cstreamOutBufSize)
+	outBuf.dst = C.malloc(cstreamOutBufSize)
 	outBuf.size = cstreamOutBufSize
 	outBuf.pos = 0
 


### PR DESCRIPTION
there is no need to zero out input/output buffers since they are not affected by https://github.com/golang/go/issues/19928
but zeroing may increase RSS for small frequent payloads

related to https://github.com/valyala/gozstd/pull/61