### PR TITLE
gozstd/decompress: introduce memory allocation limit

### DIFF
--- a/gozstd.go
+++ b/gozstd.go
@@ -189,7 +189,9 @@ func Decompress(dst, src []byte) ([]byte, error) {
 	return DecompressDict(dst, src, nil)
 }
 
-// DecompressLimited appends decompressed src to dst with given limit and returns the result.
+// DecompressLimited appends decompressed src to dst and returns the result.
+//
+// returns error if uncompressed data size exceeds provided limit
 func DecompressLimited(dst, src []byte, limit int) ([]byte, error) {
 	return decompressDict(dst, src, nil, limit)
 }
@@ -201,9 +203,11 @@ func DecompressDict(dst, src []byte, dd *DDict) ([]byte, error) {
 	return decompressDict(dst, src, dd, 0)
 }
 
-// DecompressDictLimited appends decompressed src to dst with given limit and returns the result.
+// DecompressDictLimited appends decompressed src to dst and returns the result.
 //
 // The given dictionary dd is used for the decompression.
+//
+// returns error if uncompressed data size exceeds provided limit
 func DecompressDictLimited(dst, src []byte, dd *DDict, limit int) ([]byte, error) {
 	return decompressDict(dst, src, dd, limit)
 }

--- a/gozstd.go
+++ b/gozstd.go
@@ -33,6 +33,10 @@ static unsigned long long ZSTD_findDecompressedSize_wrapper(uintptr_t src, size_
     return ZSTD_findDecompressedSize((const void*)src, srcSize);
 }
 
+static size_t ZSTD_DCtx_setMaxWindowSize_wrapper(uintptr_t ctx, size_t value) {
+    return ZSTD_DCtx_setMaxWindowSize((ZSTD_DCtx*)ctx, value);
+}
+
 */
 import "C"
 
@@ -185,11 +189,9 @@ func Decompress(dst, src []byte) ([]byte, error) {
 	return DecompressDict(dst, src, nil)
 }
 
-// DecompressLimited appends decompressed src to dst and returns the result.
-//
-// If dst has insufficient capacity for decompressed src, allocated memory is limited by maxAlloc.
-func DecompressLimited(dst, src []byte, maxAlloc int) ([]byte, error) {
-	return decompressDict(dst, src, nil, maxAlloc)
+// DecompressLimited appends decompressed src to dst with given limit and returns the result.
+func DecompressLimited(dst, src []byte, limit int) ([]byte, error) {
+	return decompressDict(dst, src, nil, limit)
 }
 
 // DecompressDict appends decompressed src to dst and returns the result.
@@ -199,16 +201,14 @@ func DecompressDict(dst, src []byte, dd *DDict) ([]byte, error) {
 	return decompressDict(dst, src, dd, 0)
 }
 
-// DecompressDictLimited appends decompressed src to dst and returns the result.
+// DecompressDictLimited appends decompressed src to dst with given limit and returns the result.
 //
 // The given dictionary dd is used for the decompression.
-//
-// If dst has insufficient capacity for decompressed src, allocated memory is limited by maxAlloc.
-func DecompressDictLimited(dst, src []byte, dd *DDict, maxAlloc int) ([]byte, error) {
-	return decompressDict(dst, src, dd, maxAlloc)
+func DecompressDictLimited(dst, src []byte, dd *DDict, limit int) ([]byte, error) {
+	return decompressDict(dst, src, dd, limit)
 }
 
-func decompressDict(dst, src []byte, dd *DDict, maxAlloc int) ([]byte, error) {
+func decompressDict(dst, src []byte, dd *DDict, limit int) ([]byte, error) {
 	var dctx, dctxDict *dctxWrapper
 	if dd == nil {
 		dctx = dctxPool.Get().(*dctxWrapper)
@@ -217,7 +217,7 @@ func decompressDict(dst, src []byte, dd *DDict, maxAlloc int) ([]byte, error) {
 	}
 
 	var err error
-	dst, err = decompress(dctx, dctxDict, dst, src, dd, maxAlloc)
+	dst, err = decompress(dctx, dctxDict, dst, src, dd, limit)
 
 	if dd == nil {
 		dctxPool.Put(dctx)
@@ -253,7 +253,7 @@ type dctxWrapper struct {
 	dctx *C.ZSTD_DCtx
 }
 
-func decompress(dctx, dctxDict *dctxWrapper, dst, src []byte, dd *DDict, maxAlloc int) ([]byte, error) {
+func decompress(dctx, dctxDict *dctxWrapper, dst, src []byte, dd *DDict, limit int) ([]byte, error) {
 	if len(src) == 0 {
 		return dst, nil
 	}
@@ -281,12 +281,12 @@ func decompress(dctx, dctxDict *dctxWrapper, dst, src []byte, dd *DDict, maxAllo
 	runtime.KeepAlive(src)
 	switch uint64(decompressBound) {
 	case uint64(C.ZSTD_CONTENTSIZE_UNKNOWN):
-		return streamDecompress(dst, src, dd)
+		return streamDecompress(dst, src, dd, limit)
 	case uint64(C.ZSTD_CONTENTSIZE_ERROR):
 		return dst, fmt.Errorf("cannot decompress invalid src")
 	}
-	if maxAlloc > 0 && decompressBound > maxAlloc {
-		return dst, fmt.Errorf("decompressBound: %d exceeds maxAlloc: %d", decompressBound, maxAlloc)
+	if limit > 0 && decompressBound > limit {
+		return dst, fmt.Errorf("decompressed source size: %d exceeds limit: %d", decompressBound, limit)
 	}
 	decompressBound++
 
@@ -331,9 +331,6 @@ func decompressInternal(dctx, dctxDict *dctxWrapper, dst, src []byte, dd *DDict)
 	// Prevent from GC'ing of dst and src during CGO calls above.
 	runtime.KeepAlive(dst)
 	runtime.KeepAlive(src)
-	runtime.KeepAlive(dctx)
-	runtime.KeepAlive(dctxDict)
-	runtime.KeepAlive(dd)
 	return n
 }
 
@@ -353,8 +350,8 @@ func ensureNoError(funcName string, result C.size_t) {
 	}
 }
 
-func streamDecompress(dst, src []byte, dd *DDict) ([]byte, error) {
-	sd := getStreamDecompressor(dd)
+func streamDecompress(dst, src []byte, dd *DDict, limit int) ([]byte, error) {
+	sd := getStreamDecompressor(dd, limit)
 	sd.dst = dst
 	sd.src = src
 	_, err := sd.zr.WriteTo(sd)
@@ -388,7 +385,7 @@ func (sd *streamDecompressor) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func getStreamDecompressor(dd *DDict) *streamDecompressor {
+func getStreamDecompressor(dd *DDict, limit int) *streamDecompressor {
 	v := streamDecompressorPool.Get()
 	if v == nil {
 		sd := &streamDecompressor{
@@ -398,6 +395,10 @@ func getStreamDecompressor(dd *DDict) *streamDecompressor {
 	}
 	sd := v.(*streamDecompressor)
 	sd.zr.Reset((*srcReader)(sd), dd)
+	if limit > 0 {
+		result := C.ZSTD_DCtx_setMaxWindowSize_wrapper(C.uintptr_t(uintptr(unsafe.Pointer(sd.zr.ds))), C.size_t(limit))
+		ensureNoError("ZSTD_DCtx_setMaxWindowSize", result)
+	}
 	return sd
 }
 

--- a/gozstd.go
+++ b/gozstd.go
@@ -264,6 +264,9 @@ func decompress(dctx, dctxDict *dctxWrapper, dst, src []byte, dd *DDict, limit i
 		result := decompressInternal(dctx, dctxDict, dst[dstLen:cap(dst)], src, dd)
 		decompressedSize := int(result)
 		if decompressedSize >= 0 {
+			if limit > 0 && decompressedSize > limit {
+				return dst, fmt.Errorf("decompressed source size: %d exceeds limit: %d", decompressedSize, limit)
+			}
 			// All OK.
 			return dst[:dstLen+decompressedSize], nil
 		}
@@ -398,6 +401,7 @@ func getStreamDecompressor(dd *DDict, limit int) *streamDecompressor {
 	if limit > 0 {
 		result := C.ZSTD_DCtx_setMaxWindowSize_wrapper(C.uintptr_t(uintptr(unsafe.Pointer(sd.zr.ds))), C.size_t(limit))
 		ensureNoError("ZSTD_DCtx_setMaxWindowSize", result)
+		sd.zr.limit = limit
 	}
 	return sd
 }

--- a/gozstd.go
+++ b/gozstd.go
@@ -185,10 +185,30 @@ func Decompress(dst, src []byte) ([]byte, error) {
 	return DecompressDict(dst, src, nil)
 }
 
+// DecompressLimited appends decompressed src to dst and returns the result.
+//
+// If dst has insufficient capacity for decompressed src, allocated memory is limited by maxAlloc.
+func DecompressLimited(dst, src []byte, maxAlloc int) ([]byte, error) {
+	return decompressDict(dst, src, nil, maxAlloc)
+}
+
 // DecompressDict appends decompressed src to dst and returns the result.
 //
 // The given dictionary dd is used for the decompression.
 func DecompressDict(dst, src []byte, dd *DDict) ([]byte, error) {
+	return decompressDict(dst, src, dd, 0)
+}
+
+// DecompressDictLimited appends decompressed src to dst and returns the result.
+//
+// The given dictionary dd is used for the decompression.
+//
+// If dst has insufficient capacity for decompressed src, allocated memory is limited by maxAlloc.
+func DecompressDictLimited(dst, src []byte, dd *DDict, maxAlloc int) ([]byte, error) {
+	return decompressDict(dst, src, dd, maxAlloc)
+}
+
+func decompressDict(dst, src []byte, dd *DDict, maxAlloc int) ([]byte, error) {
 	var dctx, dctxDict *dctxWrapper
 	if dd == nil {
 		dctx = dctxPool.Get().(*dctxWrapper)
@@ -197,7 +217,7 @@ func DecompressDict(dst, src []byte, dd *DDict) ([]byte, error) {
 	}
 
 	var err error
-	dst, err = decompress(dctx, dctxDict, dst, src, dd)
+	dst, err = decompress(dctx, dctxDict, dst, src, dd, maxAlloc)
 
 	if dd == nil {
 		dctxPool.Put(dctx)
@@ -233,7 +253,7 @@ type dctxWrapper struct {
 	dctx *C.ZSTD_DCtx
 }
 
-func decompress(dctx, dctxDict *dctxWrapper, dst, src []byte, dd *DDict) ([]byte, error) {
+func decompress(dctx, dctxDict *dctxWrapper, dst, src []byte, dd *DDict, maxAlloc int) ([]byte, error) {
 	if len(src) == 0 {
 		return dst, nil
 	}
@@ -264,6 +284,9 @@ func decompress(dctx, dctxDict *dctxWrapper, dst, src []byte, dd *DDict) ([]byte
 		return streamDecompress(dst, src, dd)
 	case uint64(C.ZSTD_CONTENTSIZE_ERROR):
 		return dst, fmt.Errorf("cannot decompress invalid src")
+	}
+	if maxAlloc > 0 && decompressBound > maxAlloc {
+		return dst, fmt.Errorf("decompressBound: %d exceeds maxAlloc: %d", decompressBound, maxAlloc)
 	}
 	decompressBound++
 
@@ -308,6 +331,9 @@ func decompressInternal(dctx, dctxDict *dctxWrapper, dst, src []byte, dd *DDict)
 	// Prevent from GC'ing of dst and src during CGO calls above.
 	runtime.KeepAlive(dst)
 	runtime.KeepAlive(src)
+	runtime.KeepAlive(dctx)
+	runtime.KeepAlive(dctxDict)
+	runtime.KeepAlive(dd)
 	return n
 }
 

--- a/gozstd_test.go
+++ b/gozstd_test.go
@@ -358,14 +358,73 @@ func TestCompressDecompressMultiFrames(t *testing.T) {
 	}
 }
 
-func TestCompressDecompressLimited(t *testing.T) {
+func TestCompressDecompressLimitedOk(t *testing.T) {
+
+	f := func(compressedData []byte, limit int) {
+		t.Helper()
+		_, err := DecompressLimited(nil, compressedData, limit)
+		if err != nil {
+			t.Fatalf("cannot decompress data with limit=%d: %s", limit, err)
+		}
+	}
 	var bb bytes.Buffer
-	for bb.Len() < 3*128*1024 {
+	for bb.Len() < 12*128*1024 {
 		fmt.Fprintf(&bb, "compress/decompress big data %d, ", bb.Len())
 	}
-	cd := Compress(nil, bb.Bytes())
-	_, err := DecompressLimited(nil, cd, 1024)
-	if err == nil {
-		t.Fatalf("expecting non-nil error when decompressing with limited memory")
+	originData := bb.Bytes()
+	// block decompression
+	cd := Compress(nil, originData)
+
+	// decompressed size matches block limit
+	f(cd, len(originData))
+
+	// unlimited
+	f(cd, 0)
+
+	// stream decompression
+	var bbCompress bytes.Buffer
+	if err := StreamCompress(&bbCompress, &bb); err != nil {
+		t.Errorf("cannot compress stream of size %d: %s", bb.Len(), err)
 	}
+	// stream compression uses adaptive window size
+	// which by default shouldn't exceed 8MB
+	// See windowLog
+	f(bbCompress.Bytes(), 8*1e6)
+
+	// stream decompression unlimited
+	f(bbCompress.Bytes(), 0)
+
+}
+
+func TestCompressDecompressLimitedFail(t *testing.T) {
+
+	f := func(compressedData []byte, limit int) {
+		t.Helper()
+		_, err := DecompressLimited(nil, compressedData, limit)
+		if err == nil {
+			t.Fatalf("expecting non-nil error when decompressing data with limit: %d", limit)
+		}
+	}
+
+	var bb bytes.Buffer
+	for bb.Len() < 12*128*1024 {
+		fmt.Fprintf(&bb, "compress/decompress big data %d, ", bb.Len())
+	}
+
+	// valid input bigger than limit
+	f(bb.Bytes(), 1024)
+
+	input, err := hex.DecodeString("28b52ffd8400005ed0b209000030ecaf4412")
+	if err != nil {
+		t.Fatalf("BUG: unexpected hex input: %s", err)
+	}
+	// input with framecontent bigger than actual payload
+	f(input, 512)
+
+	// input with stream windowSize bigger than limit
+	input, err = hex.DecodeString("28b52ffd04981900003030304e8da22b")
+	if err != nil {
+		t.Fatalf("BUG: unexpected hex input: %s", err)
+	}
+	f(input, 8*1e6*10)
 }

--- a/gozstd_test.go
+++ b/gozstd_test.go
@@ -358,22 +358,30 @@ func TestCompressDecompressMultiFrames(t *testing.T) {
 	}
 }
 
-func TestCompressDecompressLimitedOk(t *testing.T) {
+func TestCompressDecompressLimitedOK(t *testing.T) {
 
+	dst := make([]byte, 0, 512)
 	f := func(compressedData []byte, limit int) {
 		t.Helper()
-		_, err := DecompressLimited(nil, compressedData, limit)
+		var err error
+		dst, err = DecompressLimited(dst[:0], compressedData, limit)
 		if err != nil {
 			t.Fatalf("cannot decompress data with limit=%d: %s", limit, err)
 		}
 	}
+
 	var bb bytes.Buffer
 	for bb.Len() < 12*128*1024 {
 		fmt.Fprintf(&bb, "compress/decompress big data %d, ", bb.Len())
 	}
 	originData := bb.Bytes()
 	// block decompression
-	cd := Compress(nil, originData)
+	cd := Compress(nil, originData[:256])
+
+	// origin data fits dst buffer
+	f(cd, 300)
+
+	cd = Compress(nil, originData)
 
 	// decompressed size matches block limit
 	f(cd, len(originData))
@@ -397,22 +405,28 @@ func TestCompressDecompressLimitedOk(t *testing.T) {
 }
 
 func TestCompressDecompressLimitedFail(t *testing.T) {
+	dst := make([]byte, 0, 8)
 
 	f := func(compressedData []byte, limit int) {
 		t.Helper()
-		_, err := DecompressLimited(nil, compressedData, limit)
+		_, err := DecompressLimited(dst[:0], compressedData, limit)
 		if err == nil {
 			t.Fatalf("expecting non-nil error when decompressing data with limit: %d", limit)
 		}
 	}
 
 	var bb bytes.Buffer
-	for bb.Len() < 12*128*1024 {
-		fmt.Fprintf(&bb, "compress/decompress big data %d, ", bb.Len())
+	for bb.Len() < 32*1024*1024 {
+		fmt.Fprintf(&bb, "compress/decompress big raw data line %d, ", bb.Len())
 	}
 
-	// valid input bigger than limit
-	f(bb.Bytes(), 1024)
+	// valid input bigger than limit - fits allocated buffer
+	cd := Compress(nil, bb.Bytes()[:7])
+	f(cd, 5)
+
+	// valid input bigger than limit with new dst allocation
+	cd = Compress(nil, bb.Bytes()[:32])
+	f(cd, 16)
 
 	input, err := hex.DecodeString("28b52ffd8400005ed0b209000030ecaf4412")
 	if err != nil {
@@ -422,9 +436,17 @@ func TestCompressDecompressLimitedFail(t *testing.T) {
 	f(input, 512)
 
 	// input with stream windowSize bigger than limit
-	input, err = hex.DecodeString("28b52ffd04981900003030304e8da22b")
+	input, err = hex.DecodeString("28b52ffd00983d0100b401636f6d70726573732f646520626967206461746120302c2033322c0300437d0027f9268a17")
 	if err != nil {
 		t.Fatalf("BUG: unexpected hex input: %s", err)
 	}
-	f(input, 8*1e6*10)
+	f(input, 10*1e6)
+
+	// input with stream size bigger than limit
+	var compressBuf bytes.Buffer
+	if err := StreamCompress(&compressBuf, &bb); err != nil {
+		t.Fatalf("unexpected StreamCompress errror :%s", err)
+	}
+	f(compressBuf.Bytes(), 8*1e6)
+
 }

--- a/gozstd_test.go
+++ b/gozstd_test.go
@@ -357,3 +357,15 @@ func TestCompressDecompressMultiFrames(t *testing.T) {
 			plainData, origData, len(plainData), len(origData))
 	}
 }
+
+func TestCompressDecompressLimited(t *testing.T) {
+	var bb bytes.Buffer
+	for bb.Len() < 3*128*1024 {
+		fmt.Fprintf(&bb, "compress/decompress big data %d, ", bb.Len())
+	}
+	cd := Compress(nil, bb.Bytes())
+	_, err := DecompressLimited(nil, cd, 1024)
+	if err == nil {
+		t.Fatalf("expecting non-nil error when decompressing with limited memory")
+	}
+}

--- a/reader.go
+++ b/reader.go
@@ -56,6 +56,8 @@ type Reader struct {
 
 	inBufGo  cMemPtr
 	outBufGo cMemPtr
+
+	limit int
 }
 
 // NewReader returns new zstd reader reading compressed data from r.
@@ -104,6 +106,7 @@ func (zr *Reader) Reset(r io.Reader, dd *DDict) {
 	zr.inBuf.pos = 0
 	zr.outBuf.size = 0
 	zr.outBuf.pos = 0
+	zr.limit = 0
 
 	zr.dd = dd
 	initDStream(zr.ds, zr.dd)
@@ -168,6 +171,9 @@ func (zr *Reader) WriteTo(w io.Writer) (int64, error) {
 		n, err := w.Write(zr.outBufGo[zr.outBuf.pos:zr.outBuf.size])
 		zr.outBuf.pos += C.size_t(n)
 		nn += int64(n)
+		if zr.limit > 0 && nn > int64(zr.limit) {
+			return nn, fmt.Errorf("decompressed data size: %d exceeds limit: %d", nn, zr.limit)
+		}
 		if err != nil {
 			return nn, err
 		}

--- a/reader.go
+++ b/reader.go
@@ -16,7 +16,7 @@ package gozstd
 
 static size_t ZSTD_initDStream_usingDDict_wrapper(uintptr_t ds, uintptr_t dict) {
     ZSTD_DStream *zds = (ZSTD_DStream *)ds;
-    size_t rv = ZSTD_DCtx_reset(zds, ZSTD_reset_session_only);
+    size_t rv = ZSTD_DCtx_reset(zds, ZSTD_reset_session_and_parameters);
     if (rv != 0) {
         return rv;
     }


### PR DESCRIPTION
 Currently, block Decompress methods always trust frameHeader input and
 there is no way to provide a limit for it.
It allows to craft malicious package, which may allocate unbound memory and kill application.

 zstd `getFrameContentSize` method suggests to perform content size if
source is not trusted.

```
 *  note 5 : If source is untrusted, decompressed size could be wrong or intentionally modified.
 *           Always ensure return value fits within application's authorized limits.
 *           Each application can set its own limits.
```

 In addition, pure go implementation has `maxMemory` parameter to limit
memory allocation.

 This commit introduces new methods: `DecompressDictLimited` and `DecompressLimited` with `maxAlloc` parameter.
It mitigates memory allocation attack risk.