### PR TITLE
gozstd: check limit size error for streaming decompression

### DIFF
--- a/gozstd.go
+++ b/gozstd.go
@@ -358,10 +358,13 @@ func ensureNoError(funcName string, result C.size_t) {
 }
 
 func streamDecompress(dst, src []byte, dd *DDict, limit int) ([]byte, error) {
-	sd := getStreamDecompressor(dd, limit)
+	sd, err := getStreamDecompressor(dd, limit)
+	if err != nil {
+		return nil, err
+	}
 	sd.dst = dst
 	sd.src = src
-	_, err := sd.zr.WriteTo(sd)
+	_, err = sd.zr.WriteTo(sd)
 	dst = sd.dst
 	putStreamDecompressor(sd)
 	return dst, err
@@ -392,7 +395,7 @@ func (sd *streamDecompressor) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func getStreamDecompressor(dd *DDict, limit int) *streamDecompressor {
+func getStreamDecompressor(dd *DDict, limit int) (*streamDecompressor, error) {
 	v := streamDecompressorPool.Get()
 	if v == nil {
 		sd := &streamDecompressor{
@@ -404,10 +407,12 @@ func getStreamDecompressor(dd *DDict, limit int) *streamDecompressor {
 	sd.zr.Reset((*srcReader)(sd), dd)
 	if limit > 0 {
 		result := C.ZSTD_DCtx_setMaxWindowSize_wrapper(C.uintptr_t(uintptr(unsafe.Pointer(sd.zr.ds))), C.size_t(limit))
-		ensureNoError("ZSTD_DCtx_setMaxWindowSize", result)
+		if C.ZSTD_getErrorCode(result) != 0 {
+			return nil, fmt.Errorf("cannot set window size limit=%d: %s", limit, errStr(result))
+		}
 		sd.zr.limit = limit
 	}
-	return sd
+	return sd, nil
 }
 
 func putStreamDecompressor(sd *streamDecompressor) {

--- a/gozstd_test.go
+++ b/gozstd_test.go
@@ -401,7 +401,6 @@ func TestCompressDecompressLimitedOK(t *testing.T) {
 
 	// stream decompression unlimited
 	f(bbCompress.Bytes(), 0)
-
 }
 
 func TestCompressDecompressLimitedFail(t *testing.T) {
@@ -448,5 +447,27 @@ func TestCompressDecompressLimitedFail(t *testing.T) {
 		t.Fatalf("unexpected StreamCompress errror :%s", err)
 	}
 	f(compressBuf.Bytes(), 8*1e6)
+
+	// stream limit is lower than minimal window size:
+	// ZSTD_WINDOWLOG_ABSOLUTEMIN == 1 << 10
+	compressBuf.Reset()
+	bb.Reset()
+	fmt.Fprintf(&bb, "compress/decompress small data")
+	if err := StreamCompress(&compressBuf, &bb); err != nil {
+		t.Fatalf("unexpected StreamCompress errror :%s", err)
+	}
+	dst = nil
+	f(compressBuf.Bytes(), 512)
+
+	// limit is bigger than max64 window size
+	// ZSTD_WINDOWLOG_MAX 1 <<31
+	compressBuf.Reset()
+	bb.Reset()
+	fmt.Fprintf(&bb, "compress/decompress small data")
+	if err := StreamCompress(&compressBuf, &bb); err != nil {
+		t.Fatalf("unexpected StreamCompress errror :%s", err)
+	}
+	dst = nil
+	f(compressBuf.Bytes(), 1<<32)
 
 }


### PR DESCRIPTION
 Previously, incorrect limit value - too low or too high, may result in
runtime panic.

 It's not expected by caller. And it's better to return corresponding
error.